### PR TITLE
학사일정 가공 및 달력 구현

### DIFF
--- a/project/src/main/resources/static/css/calendar.css
+++ b/project/src/main/resources/static/css/calendar.css
@@ -1,0 +1,102 @@
+.rap{
+    --red:#e31b20;
+    --blue:#1b72e3;
+    --gray:#eee;
+    --white:#fff;
+    --dark:#222;
+}
+
+/* 달력 */
+.dateHead div {
+    background: var(--gray);
+    text-align: center;
+    border-radius: 5px;
+}
+
+.dateHead .date:first-child{
+    background: var(--red);
+    color: var(--white);
+}
+
+.dateHead .date:last-child{
+    background: var(--blue);
+    color: var(--white);
+}
+
+.grid {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    grid-gap: 5px;
+}
+
+.grid div {
+    padding: .6rem;
+    font-size: .9rem;
+}
+
+.dateBoard div {
+    color: var(--dark);
+    font-weight: bold;
+    min-height: 6rem;
+    padding: .6rem .8rem;
+    border-radius: 5px;
+    border: 1px solid #eee;
+}
+
+.dateBoard .redFont{
+    color: var(--red);
+}
+
+.dateBoard .blueFont{
+    color: var(--blue);
+}
+
+.noColor {
+    background: var(--gray);
+}
+
+.header {
+    display: flex;
+    justify-content: space-between;
+    padding: 1rem 2rem;
+}
+
+/* 좌우 버튼 */
+.btn {
+    display: block;
+    width: 20px;
+    height: 20px;
+    border: 3px solid #000;
+    border-width: 3px 3px 0 0;
+    cursor: pointer;
+}
+
+.prevDay {
+    transform: rotate(-135deg);
+}
+
+.nextDay {
+    transform: rotate(45deg);
+}
+
+/* ---- */
+
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css");
+
+* {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    box-sizing: border-box;
+    font-family: Pretendard;
+}
+
+.rap {
+    max-width: 820px;
+    padding: 0 1.4rem;
+    margin-top: 1.4rem;
+}
+
+.dateHead {
+    margin: .4rem 0;
+}

--- a/project/src/main/resources/static/css/calendar.css
+++ b/project/src/main/resources/static/css/calendar.css
@@ -43,6 +43,13 @@
     border: 1px solid #eee;
 }
 
+.dateBoard div div{
+    min-height: 0;
+    padding: .6rem 0;
+    text-align: center;
+    border: 0;
+}
+
 .dateBoard .redFont{
     color: var(--red);
 }
@@ -59,6 +66,14 @@
     display: flex;
     justify-content: space-between;
     padding: 1rem 2rem;
+}
+
+.infoText{
+    background: var(--gray);
+    text-align: center;
+    border-radius: 5px;
+    padding: .6rem .8rem;
+    font-weight: bold;
 }
 
 /* 좌우 버튼 */
@@ -81,14 +96,11 @@
 
 /* ---- */
 
-@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css");
-
 * {
     margin: 0;
     padding: 0;
     list-style: none;
     box-sizing: border-box;
-    font-family: Pretendard;
 }
 
 .rap {

--- a/project/src/main/resources/static/js/calendar.js
+++ b/project/src/main/resources/static/js/calendar.js
@@ -1,4 +1,13 @@
-const makeCalendar = (date) => {
+const date = new Date();
+
+updateCalendar(date);
+
+function updateCalendar(date){
+    createCalendar(date)
+        .then(getSchedule());
+}
+
+async function createCalendar(date) {
     const currentYear = new Date(date).getFullYear();
     const currentMonth = new Date(date).getMonth() + 1;
 
@@ -14,16 +23,27 @@ const makeCalendar = (date) => {
         htmlDummy += `<div class="noColor"></div>`;
     }
 
+    const strMonth = (String(currentMonth).length == 1) ? ("0" + currentMonth) : String(currentMonth);
     for (let i = 1; i <= lastDay; i++) {
         const day = firstDay + i;
         const week = 7;
 
-        if(day % week == 0){
-            htmlDummy += `<div class="blueFont">${i}</div>`;
-        } else if(day % week == 1){
-            htmlDummy += `<div class="redFont">${i}</div>`;
-        } else{
-            htmlDummy += `<div>${i}</div>`;
+        const strDay = (String(i).length == 1) ? ("0" + i) : String(i);
+        const date = String(currentYear) + strMonth + strDay;
+
+        const saturday = 0;
+        const sunday = 1;
+
+        switch (day % week){
+            case saturday:
+                htmlDummy += `<div class="blueFont" data-date="${date}">${i}</div>`;
+                break;
+            case sunday:
+                htmlDummy += `<div class="redFont" data-date="${date}">${i}</div>`;
+                break;
+            default:
+                htmlDummy += `<div data-date="${date}">${i}</div>`;
+                break;
         }
     }
 
@@ -32,20 +52,18 @@ const makeCalendar = (date) => {
     }
 
     document.querySelector(`.dateBoard`).innerHTML = htmlDummy;
-    document.querySelector(`.dateTitle`).innerText = `${currentYear}년 ${currentMonth}월`;
+    const dateTitle = document.querySelector(`.dateTitle`);
+    dateTitle.innerText = `${currentYear}년 ${currentMonth}월`;
+    dateTitle.setAttribute("data-year",String(currentYear));
+    dateTitle.setAttribute("data-month",String(currentMonth));
 }
-
-
-const date = new Date();
-
-makeCalendar(date);
 
 // 이전달 이동
 document.querySelector(`.prevDay`).onclick = () => {
-    makeCalendar(new Date(date.setMonth(date.getMonth() - 1)));
+    updateCalendar(new Date(date.setMonth(date.getMonth() - 1)));
 }
 
 // 다음달 이동
 document.querySelector(`.nextDay`).onclick = () => {
-    makeCalendar(new Date(date.setMonth(date.getMonth() + 1)));
+    updateCalendar(new Date(date.setMonth(date.getMonth() + 1)));
 }

--- a/project/src/main/resources/static/js/calendar.js
+++ b/project/src/main/resources/static/js/calendar.js
@@ -1,0 +1,51 @@
+const makeCalendar = (date) => {
+    const currentYear = new Date(date).getFullYear();
+    const currentMonth = new Date(date).getMonth() + 1;
+
+    const firstDay = new Date(date.setDate(1)).getDay();
+    const lastDay = new Date(currentYear, currentMonth, 0).getDate();
+
+    const limitDay = firstDay + lastDay;
+    const nextDay = Math.ceil(limitDay / 7) * 7;
+
+    let htmlDummy = '';
+
+    for (let i = 0; i < firstDay; i++) {
+        htmlDummy += `<div class="noColor"></div>`;
+    }
+
+    for (let i = 1; i <= lastDay; i++) {
+        const day = firstDay + i;
+        const week = 7;
+
+        if(day % week == 0){
+            htmlDummy += `<div class="blueFont">${i}</div>`;
+        } else if(day % week == 1){
+            htmlDummy += `<div class="redFont">${i}</div>`;
+        } else{
+            htmlDummy += `<div>${i}</div>`;
+        }
+    }
+
+    for (let i = limitDay; i < nextDay; i++) {
+        htmlDummy += `<div class="noColor"></div>`;
+    }
+
+    document.querySelector(`.dateBoard`).innerHTML = htmlDummy;
+    document.querySelector(`.dateTitle`).innerText = `${currentYear}년 ${currentMonth}월`;
+}
+
+
+const date = new Date();
+
+makeCalendar(date);
+
+// 이전달 이동
+document.querySelector(`.prevDay`).onclick = () => {
+    makeCalendar(new Date(date.setMonth(date.getMonth() - 1)));
+}
+
+// 다음달 이동
+document.querySelector(`.nextDay`).onclick = () => {
+    makeCalendar(new Date(date.setMonth(date.getMonth() + 1)));
+}

--- a/project/src/main/resources/static/js/calendar.js
+++ b/project/src/main/resources/static/js/calendar.js
@@ -3,18 +3,22 @@ const date = new Date();
 updateCalendar(date);
 
 function updateCalendar(date){
-    createCalendar(date)
-        .then(getSchedule());
+    createCalendar(date);
+    getSchedule();
 }
 
-async function createCalendar(date) {
+function createCalendar(date) {
     const currentYear = new Date(date).getFullYear();
     const currentMonth = new Date(date).getMonth() + 1;
 
+    // 1일의 요일
     const firstDay = new Date(date.setDate(1)).getDay();
+    // 이달의 마지막 일
     const lastDay = new Date(currentYear, currentMonth, 0).getDate();
 
+    // 1일이 항상 일요일부터 시작하지 않기때문에
     const limitDay = firstDay + lastDay;
+    // 7일 단위로 달력을 만들기 위해 7의 곱단위로 일 계산
     const nextDay = Math.ceil(limitDay / 7) * 7;
 
     let htmlDummy = '';
@@ -25,7 +29,7 @@ async function createCalendar(date) {
 
     const strMonth = (String(currentMonth).length == 1) ? ("0" + currentMonth) : String(currentMonth);
     for (let i = 1; i <= lastDay; i++) {
-        const day = firstDay + i;
+        const loopDay = firstDay + i;
         const week = 7;
 
         const strDay = (String(i).length == 1) ? ("0" + i) : String(i);
@@ -34,7 +38,7 @@ async function createCalendar(date) {
         const saturday = 0;
         const sunday = 1;
 
-        switch (day % week){
+        switch (loopDay % week){
             case saturday:
                 htmlDummy += `<div class="blueFont" data-date="${date}">${i}</div>`;
                 break;

--- a/project/src/main/resources/static/js/schedule.js
+++ b/project/src/main/resources/static/js/schedule.js
@@ -1,0 +1,106 @@
+const url = "https://open.neis.go.kr/hub/SchoolSchedule";
+const key = "d3348e90712e42a0a67f03cad20d4336";
+const type = "json";
+
+// getSchedule();
+
+// 학사일정 요청
+function getSchedule(){
+    const dataTitle = document.querySelector(`.dateTitle`);
+
+    const year = dataTitle.dataset.year;
+    let month = dataTitle.dataset.month;
+    const ATPT_OFCDC_SC_CODE = "B10";   // 시도교육청코드 (서울특별시교육청)
+    const SD_SCHUL_CODE = "7031110";    // 행정표준코드 (경기초등학교)
+
+    const url = getURL(ATPT_OFCDC_SC_CODE, SD_SCHUL_CODE, year, month);
+
+    fetch(url)
+        .then(response => response.json())
+        .then(res => scheduleProcess(res))
+        .catch(error => {
+            displayScheduleException();
+            console.log("error", error)
+        });
+
+    // https://open.neis.go.kr/hub/SchoolSchedule?
+    // Key=d3348e90712e42a0a67f03cad20d4336
+    // &Type=json
+    // &ATPT_OFCDC_SC_CODE=B10
+    // &SD_SCHUL_CODE=7031110
+    // &AA_FROM_YMD=20220301
+    // &AA_TO_YMD=20220331
+}
+
+// 요청 url 생성
+function getURL(ATPT_OFCDC_SC_CODE, SD_SCHUL_CODE, year, month){
+    if(month.length == 1){
+        month = "0" + String(month);
+    }
+    const AA_YMD = String(year) + String(month);
+    return `${url}?Key=${key}&Type=${type}&ATPT_OFCDC_SC_CODE=${ATPT_OFCDC_SC_CODE}&SD_SCHUL_CODE=${SD_SCHUL_CODE}&AA_YMD=${AA_YMD}`;
+}
+
+function getResultCode(res){
+    return res.SchoolSchedule[0].head[1].RESULT.CODE;
+}
+
+// 에러 여부 검사
+function filter(res){
+    const result = getResultCode(res);
+
+    switch (result){
+        case "INFO-000":    // 정상 처리되었습니다.
+        case "INFO-100":     // (해당 자료는 단순 참고용으로만 활용하시기 바랍니다.)
+            return true;
+        case "INFO-300":    // 관리자에 의해 인증키 사용이 제한되었습니다.
+        case "INFO-200":    // 해당하는 데이터가 없습니다.
+        case "ERROR-300":   // 필수 값이 누락되어 잇습니다. 요청인자를 참고 하십시오.
+        case "ERROR-290":   // 인증키가 유효하지 않습니다. 인증키가 없는 경우, 홈페이지에서 인증키를 신청하십시오.
+        case "ERROR-310":   // 해당 서비스를 찾을 수 없습니다. 요청인자 중 SERVICE를 확인하십시오.
+        case "ERROR-333":   // 요청위치 값의 타입이 유효하지 않습니다.요청위치 값은 정수를 입력하세요.
+        case "ERROR-336":   // 데이터요청은 한번에 최대 1,000건을 넘을 수 없습니다.
+        case "ERROR-337":   // 일별 트래픽 제한을 넘은 호출입니다. 오늘은 더이상 호출할 수 없습니다.
+        case "ERROR-500":   // 서버 오류입니다. 지속적으로 발생시 홈페이지로 문의(Q&A) 바랍니다.
+        case "ERROR-600":   // 데이터베이스 연결 오류입니다. 지속적으로 발생시 홈페이지로 문의(Q&A) 바랍니다.
+        case "ERROR-601":   // SQL 문장 오류 입니다. 지속적으로 발생시 홈페이지로 문의(Q&A) 바랍니다.
+            console.log(result);
+            return false;
+    }
+}
+
+// 학사일정 처리
+function scheduleProcess(res){
+    const success = filter(res);
+    if(success){
+        clearScheduleInfo();
+        updateSchedule(res);
+    }else{
+        displayScheduleException();
+    }
+}
+
+// 달력 업데이트
+function updateSchedule(res){
+    const row = res.SchoolSchedule[1].row;
+
+    for (let i = 0; i < row.length; i++) {
+        const eventDateBoardElement = document.querySelector(`.dateBoard div[data-date="${row[i].AA_YMD}"]`);
+
+        const html = `<div>${row[i].EVENT_NM}</div>`;
+        eventDateBoardElement.insertAdjacentHTML("beforeend", html);
+    }
+}
+
+// delete info
+function clearScheduleInfo(){
+    const dataInfoWrap = document.querySelector(`.dataInfoWrap`);
+    dataInfoWrap.innerHTML = "";
+}
+
+// display exception info
+function displayScheduleException(){
+    const dataInfoWrap = document.querySelector(`.dataInfoWrap`);
+    const html = `<div class="infoText">해당하는 데이터가 없습니다.</div>`;
+    dataInfoWrap.innerHTML = html;
+}

--- a/project/src/main/resources/static/js/schedule.js
+++ b/project/src/main/resources/static/js/schedule.js
@@ -2,14 +2,12 @@ const url = "https://open.neis.go.kr/hub/SchoolSchedule";
 const key = "d3348e90712e42a0a67f03cad20d4336";
 const type = "json";
 
-// getSchedule();
-
 // 학사일정 요청
 function getSchedule(){
     const dataTitle = document.querySelector(`.dateTitle`);
 
     const year = dataTitle.dataset.year;
-    let month = dataTitle.dataset.month;
+    const month = dataTitle.dataset.month;
     const ATPT_OFCDC_SC_CODE = "B10";   // 시도교육청코드 (서울특별시교육청)
     const SD_SCHUL_CODE = "7031110";    // 행정표준코드 (경기초등학교)
 
@@ -20,7 +18,6 @@ function getSchedule(){
         .then(res => scheduleProcess(res))
         .catch(error => {
             displayScheduleException();
-            console.log("error", error)
         });
 
     // https://open.neis.go.kr/hub/SchoolSchedule?
@@ -86,6 +83,11 @@ function updateSchedule(res){
 
     for (let i = 0; i < row.length; i++) {
         const eventDateBoardElement = document.querySelector(`.dateBoard div[data-date="${row[i].AA_YMD}"]`);
+
+        const redColor = "#e31b20";
+        if(row[i].SBTR_DD_SC_NM != "해당없음"){
+            eventDateBoardElement.style.color = redColor;
+        }
 
         const html = `<div>${row[i].EVENT_NM}</div>`;
         eventDateBoardElement.insertAdjacentHTML("beforeend", html);

--- a/project/src/main/resources/templates/schedule.html
+++ b/project/src/main/resources/templates/schedule.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>main</title>
+    <script defer src="../static/js/schedule.js"></script>
+    <script defer src="../static/js/calendar.js"></script>
+    <link rel="stylesheet" href="../static/css/calendar.css">
+</head>
+<body>
+
+<div class='rap'>
+    <div class="header">
+        <div class="btn prevDay"></div>
+        <h2 class='dateTitle'></h2>
+        <div class="btn nextDay"></div>
+    </div>
+
+    <div class="grid dateHead">
+        <div class="date">일</div>
+        <div class="date">월</div>
+        <div class="date">화</div>
+        <div class="date">수</div>
+        <div class="date">목</div>
+        <div class="date">금</div>
+        <div class="date">토</div>
+    </div>
+
+    <div class="grid dateBoard"></div>
+</div>
+
+</body>
+</html>

--- a/project/src/main/resources/templates/schedule.html
+++ b/project/src/main/resources/templates/schedule.html
@@ -17,6 +17,8 @@
         <div class="btn nextDay"></div>
     </div>
 
+    <div class="dataInfoWrap"></div>
+
     <div class="grid dateHead">
         <div class="date">일</div>
         <div class="date">월</div>


### PR DESCRIPTION
[관련 이슈](https://github.com/hyeongsi/elementary-school-community/issues/9)
[나이스 교육 개방 포털, 학사일정](https://open.neis.go.kr/portal/data/service/selectServicePage.do?page=1&rows=10&sortColumn=&sortDirection=&infId=OPEN17220190722175038389180&infSeq=2&cateId=A0005)

학사일정 데이터를 토대로 달력을 구현하여 제공

### 구현내용

 달력 구현
 다음달, 이전달 이동 및 달력 업데이트
 학사 일정 가공하여 달력에 내용 출력
 해당하는 날짜에 받아올 데이터가 없다면 안내메시지 출력
 토요일은 파란색 텍스트 출력, 일요일은 빨간색 텍스트 출력
 휴무일인 경우 빨간색 텍스트로 출력하게끔 구현하기