### PR TITLE
fix: nav-top.html 한글 깨짐 현상 수정

### DIFF
--- a/project/src/main/resources/templates/common/nav-top.html
+++ b/project/src/main/resources/templates/common/nav-top.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head th:fragment="header-head-fragment">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link
             href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css"
             rel="stylesheet"


### PR DESCRIPTION
```javascript
    <meta charset="UTF-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
```
- nav-top.html에 인코딩 방식이 누락되어 생긴 문제로, 위의 인코딩 방식을 지정하여 해결