### PR TITLE
feat: 카테고리 목록 생성 및 삭제 구현

### DIFF
--- a/project/src/main/java/com/example/project/controller/admin/AdminCategoryController.java
+++ b/project/src/main/java/com/example/project/controller/admin/AdminCategoryController.java
@@ -1,13 +1,13 @@
 package com.example.project.controller.admin;
 
+import com.example.project.dto.board.BoardDto;
 import com.example.project.dto.category.CategoryDto;
 import com.example.project.dto.category.CategoryPageDto;
+import com.example.project.dto.page.FindCategoryByBoardIdPageDto;
 import com.example.project.service.CategoryService;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -32,10 +32,26 @@ public class AdminCategoryController {
     }
 
     @GetMapping("/category")
-    public String findCategoryListById(final Model model, @RequestParam int boardId){
+    public String findCategoryListById(final Model model,
+                                       @RequestParam int boardId,
+                                       @RequestParam(defaultValue = "10") int displayUnit,
+                                       @RequestParam(defaultValue = "1") int curPage){
 
-        final List<CategoryDto> categoryList = categoryService.selectCategoryListById(boardId);
-        model.addAttribute("categoryList", categoryList);
+        final CategoryPageDto categoryPageDto = categoryService.selectCategoryListById(boardId, displayUnit, curPage);
+        model.addAttribute("categoryPageDto", categoryPageDto);
+        model.addAttribute("boardId", boardId);
         return "admin/detailBoardCategory";
+    }
+
+    @ResponseBody
+    @PostMapping("/categoryList")
+    public int categoryAdd(@RequestBody CategoryDto categoryDto){
+        return categoryService.insertCategory(categoryDto);
+    }
+
+    @ResponseBody
+    @DeleteMapping ("/categoryList")
+    public int categoryRemove(@RequestBody List<CategoryDto> categoryDtoList){
+        return categoryService.deleteCategoryList(categoryDtoList);
     }
 }

--- a/project/src/main/java/com/example/project/dto/category/CategoryDto.java
+++ b/project/src/main/java/com/example/project/dto/category/CategoryDto.java
@@ -8,12 +8,7 @@ public class CategoryDto {
     private Long categoryId;
     private String categoryName;
     private String boardName;
-
-    public CategoryDto(Long categoryId, String categoryName, String boardName) {
-        this.categoryId = categoryId;
-        this.categoryName = categoryName;
-        this.boardName = boardName;
-    }
+    private Long boardId;
 
     public Long getCategoryId() {
         return categoryId;
@@ -27,12 +22,7 @@ public class CategoryDto {
         return boardName;
     }
 
-    @Override
-    public String toString() {
-        return "CategoryDto{" +
-                "categoryId=" + categoryId +
-                ", categoryName='" + categoryName + '\'' +
-                ", boardName='" + boardName + '\'' +
-                '}';
+    public Long getBoardId() {
+        return boardId;
     }
 }

--- a/project/src/main/java/com/example/project/dto/page/FindCategoryByBoardIdPageDto.java
+++ b/project/src/main/java/com/example/project/dto/page/FindCategoryByBoardIdPageDto.java
@@ -1,0 +1,23 @@
+package com.example.project.dto.page;
+
+import org.apache.ibatis.type.Alias;
+
+@Alias("FindCategoryByBoardIdPageDto")
+public class FindCategoryByBoardIdPageDto {
+
+    private final PageDto pageDto;
+    private final int boardId;
+
+    public FindCategoryByBoardIdPageDto(PageDto pageDto, int boardId) {
+        this.pageDto = pageDto;
+        this.boardId = boardId;
+    }
+
+    public PageDto getPageDto() {
+        return pageDto;
+    }
+
+    public int getBoardId() {
+        return boardId;
+    }
+}

--- a/project/src/main/java/com/example/project/dto/page/PageDto.java
+++ b/project/src/main/java/com/example/project/dto/page/PageDto.java
@@ -1,12 +1,12 @@
-package com.example.project.dto;
+package com.example.project.dto.page;
 
 import org.apache.ibatis.type.Alias;
 
 @Alias("PageDto")
 public class PageDto {
 
-    final int start;
-    final int end;
+    private final int start;
+    private final int end;
 
     public PageDto(int start, int end) {
         this.start = start;

--- a/project/src/main/java/com/example/project/mapper/BoardMapper.java
+++ b/project/src/main/java/com/example/project/mapper/BoardMapper.java
@@ -1,7 +1,7 @@
 package com.example.project.mapper;
 
 import com.example.project.dto.board.BoardDto;
-import com.example.project.dto.PageDto;
+import com.example.project.dto.page.PageDto;
 import org.apache.ibatis.annotations.Mapper;
 import org.springframework.stereotype.Repository;
 

--- a/project/src/main/java/com/example/project/mapper/CategoryMapper.java
+++ b/project/src/main/java/com/example/project/mapper/CategoryMapper.java
@@ -1,6 +1,8 @@
 package com.example.project.mapper;
 
-import com.example.project.dto.PageDto;
+import com.example.project.dto.board.BoardDto;
+import com.example.project.dto.page.FindCategoryByBoardIdPageDto;
+import com.example.project.dto.page.PageDto;
 import com.example.project.dto.category.CategoryDto;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -12,5 +14,8 @@ public interface CategoryMapper {
     public List<CategoryDto> selectCategoryList();
     public int categoryTotalCnt();
     public List<CategoryDto> selectCategoryPage(PageDto pageDto);
-    public List<CategoryDto> selectCategoryListById(final int boardId);
+    public List<CategoryDto> selectCategoryListById(FindCategoryByBoardIdPageDto findCategoryByBoardIdPageDto);
+    public int categoryTotalCtnById(int boardId);
+    public int insertCategory(CategoryDto categoryDto);
+    public int deleteCategoryList(List<CategoryDto> categoryDtoList);
 }

--- a/project/src/main/java/com/example/project/service/BoardService.java
+++ b/project/src/main/java/com/example/project/service/BoardService.java
@@ -3,7 +3,7 @@ package com.example.project.service;
 import com.example.project.dto.board.BoardDto;
 import com.example.project.dto.board.BoardPageDto;
 import com.example.project.dto.page.Page;
-import com.example.project.dto.PageDto;
+import com.example.project.dto.page.PageDto;
 import com.example.project.mapper.BoardMapper;
 import org.springframework.stereotype.Service;
 

--- a/project/src/main/java/com/example/project/service/CategoryService.java
+++ b/project/src/main/java/com/example/project/service/CategoryService.java
@@ -1,11 +1,15 @@
 package com.example.project.service;
 
-import com.example.project.dto.PageDto;
+import com.example.project.dto.page.FindCategoryByBoardIdPageDto;
+import com.example.project.dto.page.PageDto;
 import com.example.project.dto.category.CategoryDto;
 import com.example.project.dto.category.CategoryPageDto;
 import com.example.project.dto.page.Page;
 import com.example.project.mapper.CategoryMapper;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.util.List;
 
@@ -34,7 +38,26 @@ public class CategoryService {
         return categoryPageDto;
     }
 
-    public List<CategoryDto> selectCategoryListById(final int boardId){
-        return categoryMapper.selectCategoryListById(boardId);
+    public CategoryPageDto selectCategoryListById(final int boardId, final int displayUnit, final int curPage){
+
+        final int totalCnt = categoryMapper.categoryTotalCtnById(boardId);
+        final Page page = new Page(displayUnit, curPage, totalCnt);
+
+        final PageDto pageDto = new PageDto(page.getStartNum(), page.getEndNum());
+        final FindCategoryByBoardIdPageDto findCategoryByBoardIdPageDto =
+                new FindCategoryByBoardIdPageDto(pageDto, boardId);
+
+        final List<CategoryDto> categoryDtoList = categoryMapper.selectCategoryListById(findCategoryByBoardIdPageDto);
+
+        final CategoryPageDto categoryPageDto = new CategoryPageDto(page, categoryDtoList);
+        return categoryPageDto;
+    }
+
+    public int insertCategory(final CategoryDto categoryDto){
+        return categoryMapper.insertCategory(categoryDto);
+    }
+
+    public int deleteCategoryList(List<CategoryDto> categoryDtoList){
+        return categoryMapper.deleteCategoryList(categoryDtoList);
     }
 }

--- a/project/src/main/resources/com/config/CategoryMapper.xml
+++ b/project/src/main/resources/com/config/CategoryMapper.xml
@@ -15,18 +15,44 @@
     </select>
 
     <select id="selectCategoryPage" resultType="CategoryDto" parameterType="PageDto">
-        SELECT category_id, category_name, board_name
-        FROM (SELECT rownum rm, c.category_id, c.category_name, b.board_name
-             FROM category c JOIN board b
-             ON c.board_id = b.board_id)
+        SELECT rm, category_id, category_name, board_name
+        FROM (SELECT rownum rm, category_id, category_name, board_name
+              FROM (SELECT c.category_id, c.category_name, b.board_name
+                    FROM category c JOIN board b
+                    ON c.board_id = b.board_id
+                    ORDER BY c.category_id DESC))
         WHERE rm between #{start} AND #{end}
     </select>
 
-    <select id="selectCategoryListById" resultType="CategoryDto" parameterType="int">
-        SELECT c.category_id, c.category_name, b.board_name
-        FROM category c JOIN board b
-        ON c.board_id = b.board_id
-        WHERE c.board_id = #{boardId}
+    <select id="selectCategoryListById" resultType="CategoryDto" parameterType="FindCategoryByBoardIdPageDto">
+        SELECT rm, category_id, category_name, board_name
+        FROM (SELECT rownum rm, category_id, category_name, board_name
+              FROM (SELECT c.category_id, c.category_name, b.board_name, c.board_id
+                    FROM category c JOIN board b
+                    ON c.board_id = b.board_id
+                    ORDER BY c.category_id DESC)
+              WHERE board_id = #{boardId})
+        WHERE rm between #{pageDto.start} AND #{pageDto.end}
     </select>
+
+    <select id="categoryTotalCtnById" resultType="int" parameterType="int">
+        SELECT count(*)
+        FROM category
+        WHERE board_id = #{boardId}
+    </select>
+
+    <insert id="insertCategory" parameterType="CategoryDto">
+        INSERT INTO category(category_id, category_name, board_id)
+        VALUES(seq_category.nextval, #{categoryName}, #{boardId})
+    </insert>
+
+    <delete id="deleteCategoryList" parameterType="List">
+        DELETE FROM category
+        WHERE category_id IN (
+        <foreach collection="categoryDtoList" item="item" separator=",">
+            #{item.categoryId}
+        </foreach>
+        )
+    </delete>
 
 </mapper>

--- a/project/src/main/resources/static/js/categoryList.js
+++ b/project/src/main/resources/static/js/categoryList.js
@@ -1,6 +1,6 @@
-function allBoardCk(ckBox){
+function allCategoryCk(ckBox){
     const isCk = ckBox.checked;
-    
+
     // 전체 체크박스 체크여부 토글 적용
     const query = "input[name='boardCk']";
     const ckBoxes = document.querySelectorAll(query);
@@ -9,19 +9,21 @@ function allBoardCk(ckBox){
     }
 }
 
-function createBoard(){
-    const input = prompt("생성할 게시판의 제목을 입력하세요.");
-    if(input == null || input == "")
+function createCategory(element){
+    const inputCategoryName = prompt("생성할 카테고리의 제목을 입력하세요.");
+    if(inputCategoryName == null || inputCategoryName == "")
         return;
 
-    const url = "http://localhost:8088/app/admin/boardList";
+    const boardId = element.dataset['boardid'];
+    const url = "http://localhost:8088/app/admin/categoryList";
     fetch(url, {
         method: "POST",
         headers:{
             "Content-Type":"application/json",
         },
         body: JSON.stringify({
-            boardName: input,
+            categoryName: inputCategoryName,
+            boardId: boardId,
         }),
     })
         .then(response => response.json())
@@ -37,8 +39,8 @@ function createBoard(){
         .catch(error => alert("생성에 실패했습니다."));
 }
 
-function removeBoard() {
-    const query = "input[name='boardCk']:checked";
+function removeCategory() {
+    const query = "input[name='categoryCk']:checked";
     const ckBoxes = document.querySelectorAll(query);
     if(ckBoxes.length == 0)
         return;
@@ -48,11 +50,11 @@ function removeBoard() {
         const arr = [];
         for (let i = 0; i < ckBoxes.length; i++) {
             let obj = {};
-            obj.boardId = ckBoxes[i].dataset['boardid'];
+            obj.categoryId = ckBoxes[i].dataset['categoryid'];
             arr.push(obj);
         }
 
-        const url =  "http://localhost:8088/app/admin/boardList";
+        const url =  "http://localhost:8088/app/admin/categoryList";
         fetch(url, {
             method: "DELETE",
             headers:{
@@ -68,6 +70,7 @@ function removeBoard() {
                     return;
                 }
                 alert("삭제에 실패했습니다.")
+                return;
             })
             .catch(error => alert("삭제에 실패했습니다."));
     }

--- a/project/src/main/resources/templates/admin/categoryList.html
+++ b/project/src/main/resources/templates/admin/categoryList.html
@@ -64,8 +64,6 @@
                                 </div>
                                 <div class="col-sm-12 col-md-6">
                                     <div class="d-flex justify-content-end">
-                                        <button class="btn btn-sm btn-outline-primary mr-3" type="button">생성</button>
-                                        <button class="btn btn-sm btn-outline-danger" type="button">삭제</button>
                                     </div>
                                 </div>
                             </div>
@@ -77,7 +75,6 @@
                                                style="text-align: center">
                                             <thead style="text-align: center">
                                             <tr>
-                                                <th style="min-width: 50px"><input type="checkbox"></th>
                                                 <th style="min-width: 50px">번호</th>
                                                 <th style="min-width: 150px">카테고리 이름</th>
                                                 <th style="min-width: 150px">게시판 이름</th>
@@ -85,7 +82,6 @@
                                             </thead>
                                             <tbody>
                                             <tr th:each="categoryDto : ${categoryPageDto.categoryDtoList}">
-                                                <td><input type="checkbox" data-no="${categoryDto.categoryId}"></td>
                                                 <td th:text="${categoryDto.categoryId}">null</td>
                                                 <td th:text="${categoryDto.categoryName}">null</td>
                                                 <td th:text="${categoryDto.boardName}">null</td>

--- a/project/src/main/resources/templates/admin/detailBoardCategory.html
+++ b/project/src/main/resources/templates/admin/detailBoardCategory.html
@@ -19,7 +19,7 @@
 
     <!-- Custom styles for this page -->
     <link th:href="@{/vendor/datatables/dataTables.bootstrap4.min.css}" rel="stylesheet">
-
+    <script defer src="/app/js/categoryList.js"></script>
 </head>
 
 <body id="page-top">
@@ -54,18 +54,18 @@
                             <div class="row mt-3">
                                 <div class="col-sm-12 col-md-6">
                                     <div class="dataTables_length" id="dataTable_length"><label>보기 <select
-                                            name="dataTable_length" aria-controls="dataTable"
+                                            name="dataTable_length" th:onchange="|location.href='@{/admin/category}?displayUnit=' + this.value + '&boardId=${boardId}'|"
                                             class="custom-select custom-select-sm form-control form-control-sm">
-                                        <option value="10">10</option>
-                                        <option value="25">25</option>
-                                        <option value="50">50</option>
-                                        <option value="100">100</option>
+                                        <option th:selected="${categoryPageDto.page.displayUnit} == 10" value="10">10</option>
+                                        <option th:selected="${categoryPageDto.page.displayUnit} == 25" value="25">25</option>
+                                        <option th:selected="${categoryPageDto.page.displayUnit} == 50" value="50">50</option>
+                                        <option th:selected="${categoryPageDto.page.displayUnit} == 100" value="100">100</option>
                                     </select> 단위</label></div>
                                 </div>
                                 <div class="col-sm-12 col-md-6">
                                     <div class="d-flex justify-content-end">
-                                        <button class="btn btn-sm btn-outline-primary mr-3" type="button">생성</button>
-                                        <button class="btn btn-sm btn-outline-danger" type="button">삭제</button>
+                                        <button class="btn btn-sm btn-outline-primary mr-3" onclick="createCategory(this)" th:data-boardId="${boardId}" type="button">생성</button>
+                                        <button class="btn btn-sm btn-outline-danger" onclick="removeCategory()" type="button">삭제</button>
                                     </div>
                                 </div>
                             </div>
@@ -77,18 +77,18 @@
                                                style="text-align: center">
                                             <thead style="text-align: center">
                                             <tr>
-                                                <th style="min-width: 50px"><input type="checkbox"></th>
+                                                <th style="min-width: 50px"><input type="checkbox" onclick="allCategoryCk(this)"></th>
                                                 <th style="min-width: 50px">번호</th>
                                                 <th style="min-width: 150px">카테고리 이름</th>
                                                 <th style="min-width: 150px">게시판 이름</th>
                                             </tr>
                                             </thead>
                                             <tbody>
-                                            <tr th:each="category : ${categoryList}">
-                                                <td><input type="checkbox" data-no="${category.categoryId}"></td>
-                                                <td th:text="${category.categoryId}">null</td>
-                                                <td th:text="${category.categoryName}">null</td>
-                                                <td th:text="${category.boardName}">null</td>
+                                            <tr th:each="categoryDto : ${categoryPageDto.categoryDtoList}">
+                                                <td><input th:if="${categoryDto.categoryId > 17}" type="checkbox" name="categoryCk" th:data-categoryid="${categoryDto.categoryId}"></td>
+                                                <td th:text="${categoryDto.categoryId}">null</td>
+                                                <td th:text="${categoryDto.categoryName}">null</td>
+                                                <td th:text="${categoryDto.boardName}">null</td>
                                             </tr>
                                             </tbody>
                                         </table>
@@ -100,38 +100,26 @@
                             <!-- pagenation -->
                             <div class="row">
                                 <div class="col-sm-12 col-md-5">
-                                    <div class="dataTables_info" id="dataTable_info" role="status" aria-live="polite">
-                                        Showing 1 to 10 of 57 entries
+                                    <div class="dataTables_info" id="dataTable_info" role="status" aria-live="polite"
+                                         th:text="|Showing ${categoryPageDto.page.curPage} to ${categoryPageDto.page.maxPage} of ${categoryPageDto.page.totalCnt} entries|">
                                     </div>
                                 </div>
                                 <div class="col-sm-12 col-md-7">
                                     <div class="dataTables_paginate paging_simple_numbers" id="dataTable_paginate">
                                         <ul class="pagination">
-                                            <li class="paginate_button page-item previous disabled"
-                                                id="dataTable_previous"><a href="#" aria-controls="dataTable"
-                                                                           data-dt-idx="0" tabindex="0"
-                                                                           class="page-link">Previous</a></li>
-                                            <li class="paginate_button page-item active"><a href="#"
-                                                                                            aria-controls="dataTable"
-                                                                                            data-dt-idx="1" tabindex="0"
-                                                                                            class="page-link">1</a></li>
-                                            <li class="paginate_button page-item "><a href="#" aria-controls="dataTable"
-                                                                                      data-dt-idx="2" tabindex="0"
-                                                                                      class="page-link">2</a></li>
-                                            <li class="paginate_button page-item "><a href="#" aria-controls="dataTable"
-                                                                                      data-dt-idx="3" tabindex="0"
-                                                                                      class="page-link">3</a></li>
-                                            <li class="paginate_button page-item "><a href="#" aria-controls="dataTable"
-                                                                                      data-dt-idx="4" tabindex="0"
-                                                                                      class="page-link">4</a></li>
-                                            <li class="paginate_button page-item "><a href="#" aria-controls="dataTable"
-                                                                                      data-dt-idx="5" tabindex="0"
-                                                                                      class="page-link">5</a></li>
-                                            <li class="paginate_button page-item next" id="dataTable_next"><a href="#"
-                                                                                                              aria-controls="dataTable"
-                                                                                                              data-dt-idx="7"
-                                                                                                              tabindex="0"
-                                                                                                              class="page-link">Next</a>
+                                            <li class="paginate_button page-item previous" id="dataTable_previous"
+                                                th:classappend="${categoryPageDto.page.curPage == 1} ? 'disabled' : '' ">
+                                                <a href="#" th:href="@{/admin/category(boardId=${boardId},displayUnit=${categoryPageDto.page.displayUnit},curPage=${categoryPageDto.page.curPage - 1})}" class="page-link">Previous</a>
+                                            </li>
+                                            <th:block th:each="num : ${#numbers.sequence(categoryPageDto.page.startPage,
+                                                                                        categoryPageDto.page.endPage)}">
+                                                <li class="paginate_button page-item" th:classappend="${num == categoryPageDto.page.curPage} ? 'active' : '' ">
+                                                    <a href="#" th:href="@{/admin/category(boardId=${boardId},displayUnit=${categoryPageDto.page.displayUnit},curPage=${num})}" class="page-link" th:text="${num}"></a>
+                                                </li>
+                                            </th:block>
+                                            <li class="paginate_button page-item next" id="dataTable_next"
+                                                th:classappend="${categoryPageDto.page.curPage == categoryPageDto.page.endPage} ? 'disabled' : '' ">
+                                                <a href="#" th:href="@{/admin/category(boardId=${boardId},displayUnit=${categoryPageDto.page.displayUnit},curPage=${categoryPageDto.page.curPage + 1})}"  class="page-link">Next</a>
                                             </li>
                                         </ul>
                                     </div>


### PR DESCRIPTION
어드민페이지 - 카테고리 목록

## 구현내용
* app/admin/categoryList를 통해 전체 카테고리 목록 확인 가능
* app/admin/category?boardId=62를 통해 특정 게시판의 하위 카테고리 목록 확인 가능

* - 삭제할 요소가 없음에도 삭제메시지 뜨던 문제 해결 체크요소 가져오고 요소가 0개라면 종료시킴

```javascript
    const query = "input[name='categoryCk']:checked";
    const ckBoxes = document.querySelectorAll(query);
    if(ckBoxes.length == 0)
        return;
```

*  생성 및 삭제 시 실패했음에도 조건문에서 벗어나 완료되었다고 뜨던 문제 해결 실패 시 0값을 반환하는것으로 생각하고 구문을 작성했으나, sql에러가 뜨면 500이나 400을 포함한 응답메시지가 와서 생긴 문제로 조건문 구문을 성공했을때로
판단하여 메시지 출력 후 return하게 해서 해결함

```javascript
            .then(response => response.json())
            .then(result => {
                if(result >= 1){
                    alert("성공적으로 삭제되었습니다.")
                    window.location.reload();
                    return;
                }
                alert("삭제에 실패했습니다.")
                return;
            })
            .catch(error => alert("삭제에 실패했습니다."));
```

* 카테고리 목록에서는 생성할 필요가 없기 때문에 체크박스 삭제함

* dto에 생성자가 있다면 요청값을 받을 때나 sql구문 실행 이후 dto 반환할 때 문제가 생길 수 있다. 생성자를 제거하니 각종 에러 없어짐.

* 기타 페이징 처리
--- 

- [x] 특정 게시판의 카테고리 목록 조회
- [x] 전체 카테고리 목록 조회
- [x] 카테고리 추가
- [x] 카테고리 삭제
- [x] 카테고리 페이징  
